### PR TITLE
Adopt MimeTypes from Ark

### DIFF
--- a/extract_here_and_delete.desktop
+++ b/extract_here_and_delete.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Service
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin
-MimeType=application/x-*;application/gzip;application/java-archive;application/vnd.android.package-archive;application/vnd.debian.binary-package;application/vnd.ms-cab-compressed;application/zip;application/zstd
+MimeType=application/x-deb;application/x-cd-image;application/x-bcpio;application/x-cpio;application/x-cpio-compressed;application/x-sv4cpio;application/x-sv4crc;application/x-rpm;application/x-compress;application/gzip;application/x-bzip;application/x-bzip2;application/x-lzma;application/x-xz;application/zlib;application/zstd;application/x-lz4;application/x-lzip;application/x-lrzip;application/x-lzop;application/x-source-rpm;application/vnd.debian.binary-package;application/vnd.ms-cab-compressed;application/vnd.android.package-archive;application/x-xar;application/x-iso9660-appimage;application/x-archive;application/x-tar;application/x-compressed-tar;application/x-bzip-compressed-tar;application/x-bzip2-compressed-tar;application/x-tarz;application/x-xz-compressed-tar;application/x-lzma-compressed-tar;application/x-lzip-compressed-tar;application/x-tzo;application/x-lrzip-compressed-tar;application/x-lz4-compressed-tar;application/x-zstd-compressed-tar;application/vnd.rar;application/x-7z-compressed;application/zip;application/x-java-archive;application/java-archive;application/x-lha;application/x-stuffit;application/x-arj;application/arj;
 Actions=extractAndDelete
 
 [Desktop Action extractAndDelete]


### PR DESCRIPTION
This PR integrates all missing MimeTypes that Ark itself supports and removes duplicates.